### PR TITLE
build: reduce dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .target(
             name: "GameOfLife",
             dependencies: [
-                .product(name: "Collections", package: "swift-collections")
+                .product(name: "BitCollections", package: "swift-collections")
             ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),

--- a/Sources/GameOfLife/CellularAutomaton.swift
+++ b/Sources/GameOfLife/CellularAutomaton.swift
@@ -1,4 +1,4 @@
-import Collections
+import BitCollections
 
 public enum Neighborhood {
     case vonNeumann


### PR DESCRIPTION
GameOfLife depends on `BitCollections`, so it doesn't need the other modules.