### PR TITLE
refactor: replace swift-collection's BitArray with my own BitField

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1a87f2af2c343dd2b22bab0a8e20a6d040e18948354d04a3c3a4e181799e6c20",
+  "originHash" : "35aae08a5ee9438a3989b0115d6a4166c856065eada854d79c4575f2a42ad16a",
   "pins" : [
     {
       "identity" : "swift-async-algorithms",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "branch" : "main",
-        "revision" : "7c9df0070615b888fc9c30429ad33b4d69702b45"
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,15 +18,11 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-collections", branch: "main"),
+        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0")
     ],
     targets: [
         .target(
             name: "GameOfLife",
-            dependencies: [
-                .product(name: "BitCollections", package: "swift-collections")
-            ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableUpcomingFeature("BareSlashRegexLiterals"),

--- a/Sources/GameOfLife/BitField.swift
+++ b/Sources/GameOfLife/BitField.swift
@@ -1,0 +1,150 @@
+@usableFromInline struct BitField {
+    private var inner: [UInt]
+    public let count: Int
+
+    public init(count: Int) {
+        precondition(count > 0)
+        let (q, r) = count.quotientAndRemainder(dividingBy: UInt.bitWidth)
+        self.inner = .init(repeating: 0, count: r > 0 ? q + 1 : q)
+        self.count = count
+    }
+
+    public static func randomBits(count: Int) -> Self {
+        precondition(count > 0)
+        let (q, r) = count.quotientAndRemainder(dividingBy: UInt.bitWidth)
+        let innerCount = r > 0 ? q + 1 : q
+        return .init(
+            inner: .init(unsafeUninitializedCapacity: innerCount) { buf, count in
+                for i in 0..<innerCount {
+                    buf[i] = .random(in: UInt.min...UInt.max)
+                }
+                count = innerCount
+            },
+            count: count
+        )
+    }
+
+    private init(inner: [UInt], count: Int) {
+        self.inner = inner
+        self.count = count
+    }
+
+    public subscript(index: Int) -> Bool {
+        get {
+            precondition(index < self.count)
+            let (q, r) = index.quotientAndRemainder(dividingBy: UInt.bitWidth)
+            return self.inner[self.inner.count - 1 - q] >> r & 1 > 0
+        }
+        set {
+            precondition(index < self.count)
+            let (q, r) = index.quotientAndRemainder(dividingBy: UInt.bitWidth)
+            if newValue {
+                self.inner[self.inner.count - 1 - q] |= 1 << r
+            } else {
+                self.inner[self.inner.count - 1 - q] &= ~(1 << r)
+            }
+        }
+    }
+
+    public mutating func clear() {
+        for i in self.inner.indices {
+            self.inner[i] = 0
+        }
+    }
+}
+
+// Bitwise operators
+extension BitField {
+    public static func |= (lhs: inout Self, rhs: Self) {
+        precondition(lhs.count == rhs.count)
+        lhs.inner = zip(lhs.inner, rhs.inner).map(|)
+    }
+
+    public static func &= (lhs: inout Self, rhs: Self) {
+        precondition(lhs.count == rhs.count)
+        lhs.inner = zip(lhs.inner, rhs.inner).map(&)
+    }
+
+    public static func ^= (lhs: inout Self, rhs: Self) {
+        precondition(lhs.count == rhs.count)
+        lhs.inner = zip(lhs.inner, rhs.inner).map(^)
+    }
+
+    public static func | (lhs: Self, rhs: Self) -> Self {
+        var newValue = lhs
+        newValue |= rhs
+        return newValue
+    }
+
+    public static func & (lhs: Self, rhs: Self) -> Self {
+        var newValue = lhs
+        newValue &= rhs
+        return newValue
+    }
+
+    public static func ^ (lhs: Self, rhs: Self) -> Self {
+        var newValue = lhs
+        newValue ^= rhs
+        return newValue
+    }
+
+    public static prefix func ~ (value: Self) -> Self {
+        .init(inner: value.inner.map(~), count: value.count)
+    }
+}
+
+// Bit shifting operators
+extension BitField {
+    public static func <<= (lhs: inout Self, rhs: Int) {
+        guard rhs != 0 else { return }
+        if rhs > 0 {
+            lhs.shiftLeft(by: rhs)
+        } else {
+            lhs.shiftRight(by: -rhs)
+        }
+    }
+
+    public static func >>= (lhs: inout Self, rhs: Int) {
+        guard rhs != 0 else { return }
+        if rhs > 0 {
+            lhs.shiftRight(by: rhs)
+        } else {
+            lhs.shiftLeft(by: -rhs)
+        }
+    }
+
+    public static func << (lhs: Self, rhs: Int) -> Self {
+        var newValue = lhs
+        newValue <<= rhs
+        return newValue
+    }
+
+    public static func >> (lhs: Self, rhs: Int) -> Self {
+        var newValue = lhs
+        newValue >>= rhs
+        return newValue
+    }
+
+    private mutating func shiftLeft(by amount: Int) {
+        assert(amount > 0)
+        precondition(amount <= UInt.bitWidth)
+        let remaining = UInt.bitWidth - amount
+        for i in self.inner.indices.lazy.dropLast() {
+            self.inner[i] <<= amount
+            self.inner[i] |= self.inner[i + 1] >> remaining
+        }
+        self.inner[self.inner.count - 1] <<= amount
+    }
+
+    private mutating func shiftRight(by amount: Int) {
+        assert(amount > 0)
+        precondition(amount <= UInt.bitWidth)
+        let remaining = UInt.bitWidth - amount
+        for i in self.inner.indices.lazy.dropFirst().reversed() {
+            self.inner[i] >>= amount
+            self.inner[i] |= self.inner[i - 1] << remaining
+        }
+        self.inner[0] >>= amount
+        self.inner[0] &= ~(UInt.max << remaining)
+    }
+}

--- a/Sources/GameOfLife/CellularAutomaton.swift
+++ b/Sources/GameOfLife/CellularAutomaton.swift
@@ -1,5 +1,3 @@
-import BitCollections
-
 public enum Neighborhood {
     case vonNeumann
     case moore
@@ -15,21 +13,21 @@ public struct CellularAutomaton {
     public let neighborhood: Neighborhood
     /// The current time step.
     public private(set) var time = 0
-    @usableFromInline var map: [BitArray]
+    @usableFromInline var map: [BitField]
 
     /// An initializer.
     public init(width: Int, height: Int, neighborhood: Neighborhood = .moore) {
         self.width = width
         self.height = height
         self.neighborhood = neighborhood
-        self.map = .init(repeating: .init(repeating: false, count: width), count: height)
+        self.map = .init(repeating: .init(count: width), count: height)
     }
 
     /// Resets to the initial state.
     public mutating func clear() {
         self.time = 0
         for i in self.map.indices {
-            self.map[i].fill(with: false)
+            self.map[i].clear()
         }
     }
 
@@ -85,27 +83,21 @@ public struct CellularAutomaton {
         self.map = nextMap
     }
 
-    private static func next(of line: BitArray, prev: BitArray, next: BitArray) -> BitArray {
-        var a = prev
-        a.maskingShiftRight(by: 1)
-        a[a.endIndex - 1] = prev[0]
+    private static func next(of line: BitField, prev: BitField, next: BitField) -> BitField {
+        var a = prev >> 1
+        a[a.count - 1] = prev[0]
         var b = prev
-        var c = prev
-        c.maskingShiftLeft(by: 1)
-        c[0] = prev[prev.endIndex - 1]
-        var d = line
-        d.maskingShiftRight(by: 1)
-        d[d.endIndex - 1] = line[0]
-        var e = line
-        e.maskingShiftLeft(by: 1)
-        e[0] = line[line.endIndex - 1]
-        var f = next
-        f.maskingShiftRight(by: 1)
-        f[f.endIndex - 1] = next[0]
+        var c = prev << 1
+        c[0] = prev[prev.count - 1]
+        var d = line >> 1
+        d[d.count - 1] = line[0]
+        var e = line << 1
+        e[0] = line[line.count - 1]
+        var f = next >> 1
+        f[f.count - 1] = next[0]
         var g = next
-        var h = next
-        h.maskingShiftLeft(by: 1)
-        h[0] = next[next.endIndex - 1]
+        var h = next << 1
+        h[0] = next[next.count - 1]
 
         let xab = a & b
         a ^= b


### PR DESCRIPTION
swift-collections 1.1 has dropped support for bitwise operators of `BitArray`, so I replaced it with my own `BitField`.

This can be ported to Embedded Swift version too.