### PR TITLE
build: always enable optimization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,9 @@ let package = Package(
         .target(
             name: "GameOfLife",
             swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny")
+                .unsafeFlags(["-O"]),
+                .unsafeFlags(["-cross-module-optimization"]),
+                .enableUpcomingFeature("ExistentialAny"),
             ]
         ),
         .executableTarget(
@@ -37,6 +39,8 @@ let package = Package(
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
                 .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
                 .unsafeFlags(["-Xfrontend", "-enable-actor-data-race-checks"]),
+                .unsafeFlags(["-O"]),
+                .unsafeFlags(["-cross-module-optimization"]),
                 .enableUpcomingFeature("ExistentialAny"),
             ]
         ),


### PR DESCRIPTION
This PR adds `-O` and `-cross-module-optimization` to both `GameOfLife` and `AppModule`. On my M4 iPad Pro, refreshing App Preview does not take so long.